### PR TITLE
🔧 ini_setting class

### DIFF
--- a/manifests/ini.pp
+++ b/manifests/ini.pp
@@ -3,10 +3,9 @@
 # Modify settings in ini files
 #
 class dc_openstack::ini (
- 
-  Hash $defaults,
-
+  String $path,
 ){
-  create_resources('ini_setting', hiera_hash('settings'), $defaults)
+  create_resources('ini_setting', hiera_hash('settings'), { path => $path })
+  Package<||> -> Ini_setting<||>
 }
 


### PR DESCRIPTION
This PR removes the opaque abstraction of a set of 'defaults' that get passed in. This previously meant that dependancies (such as packages) had to be defined in Hiera.

Instead we explicitly expect a path to a file that the resulting ini settings are applied to, and ensure that ordering is broadly handled by making sure all Package resources are included before any Ini_settings.